### PR TITLE
Add missing transaction rollback in certain failure scenarios

### DIFF
--- a/queue/sqlite/sqlite.go
+++ b/queue/sqlite/sqlite.go
@@ -135,11 +135,12 @@ func (q *SQLiteQueue) DeleteQueue(tenantId int64, queue string) error {
 		return err
 	}
 
+	defer tx.Rollback() // This will be a no-op if tx.Commit() is called
+
 	var queueId int64
 	row := tx.QueryRow("select id from queues where name = ? and tenant_id = ?", strings.ToLower(queue), tenantId)
 	err = row.Scan(&queueId)
 	if err != nil {
-		tx.Rollback()
 		return err
 	}
 

--- a/queue/sqlite/sqlite.go
+++ b/queue/sqlite/sqlite.go
@@ -135,7 +135,7 @@ func (q *SQLiteQueue) DeleteQueue(tenantId int64, queue string) error {
 		return err
 	}
 
-	defer tx.Rollback() // This will be a no-op if tx.Commit() is called
+	defer tx.Rollback()
 
 	var queueId int64
 	row := tx.QueryRow("select id from queues where name = ? and tenant_id = ?", strings.ToLower(queue), tenantId)


### PR DESCRIPTION
We only rollback after the first select fails. I am adding a defer to rollback which should be a no-op if the commit went through.