### PR TITLE
config: Add `--sqs-endpoint` option

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -60,6 +60,7 @@ type SQSConfig struct {
 	MaxRequestSize   int      `name:"max-request-size" default:"1048576" env:"MAX_REQUEST_SIZE" help:"Max size of SQS request in bytes"`
 	MaxDelaySeconds  int      `name:"max-delay-seconds" default:"30" env:"MAX_DELAY_SECONDS" help:"Max allowed wait time for long polling"`
 	DelayRetryMillis int      `name:"delay-retry-millis" default:"1000" env:"DELAY_RETRY_MILLIS" help:"When long polling, how often to request new items"`
+	Endpoint         string   `name:"endpoint" default:"https://sqs.us-east-1.amazonaws.com" env:"ENDPOINT" help:"Endpoint to advertise in queue URLs"`
 }
 
 type AWSKey struct {

--- a/protocols/sqs/sqs.go
+++ b/protocols/sqs/sqs.go
@@ -255,16 +255,15 @@ func (s *SQS) CreateQueue(c *fiber.Ctx, tenantId int64) error {
 		return err
 	}
 
-	queueUrl := fmt.Sprintf("https://sqs.us-east-1.amazonaws.com/%d/%s", tenantId, req.QueueName)
 	rc := CreateQueueResponse{
-		QueueUrl: queueUrl,
+		QueueUrl: s.queueURL(tenantId, req.QueueName),
 	}
 
 	return c.JSON(rc)
 }
 
 func (s *SQS) queueURL(tenantId int64, queue string) string {
-	return fmt.Sprintf("https://sqs.us-east-1.amazonaws.com/%d/%s", tenantId, queue)
+	return fmt.Sprintf("%s/%d/%s", s.cfg.Endpoint, tenantId, queue)
 
 }
 func (s *SQS) ListQueues(c *fiber.Ctx, tenantId int64) error {


### PR DESCRIPTION
Hi @poundifdef, thank you very much for sharing this program. I'm very excited to have this simple tool in my kit.

I was writing some test cases for a Clojure client using [amazonica](https://github.com/mcohen01/amazonica) which is sugar around the underlying official AWS SDK, and ran into a roadblock sending messages to a queue. Due to the queue URLs being advertised as `https://sqs.us-east-1.amazonaws.com/<tenant>/<queue-name>`, the official Java SDK was failing to send messages since it was trying to hit the actual amazonaws.com endpoints.

Here is a simple patch to publish true queue URLs. I kept the default behavior here to pretend to be sqs.us-east-1.amazonaws.com for compatibility.

----

Provide an option to set the _advertised_ endpoint for the SQS queue URLs. The official AWS client for Java will connect to the queue url as advertised by the server, regardless of what the `endpoint` is configured to in the top level AWS client.

When running SmoothMQ behind a load balancer, this should be the public endpoint of the server.