### PR TITLE
Add support for https endpoint

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,6 +7,12 @@ server:
       - accesskey: DEV_ACCESS_KEY_ID
         secretkey: DEV_SECRET_ACCESS_KEY
 
+# Allow for tls based servers
+#  tls:
+#    cert: /shared/ssl-certs/bundle.pem
+#    private-key: /shared/ssl-certs/pk.pem
+
+
   dashboard:
     enabled: true
     port: 3000

--- a/config/config.go
+++ b/config/config.go
@@ -29,6 +29,7 @@ type TesterCommand struct {
 
 type ServerCommand struct {
 	SQS       SQSConfig       `embed:"" prefix:"sqs-" envprefix:"Q_SQS_"`
+	TLS       TLSConfig       `embed:"" prefix:"tls-" envprefix:"Q_TLS_"`
 	Dashboard DashboardConfig `embed:"" prefix:"dashboard-" envprefix:"Q_DASHBOARD_"`
 	SQLite    SQLiteConfig    `embed:"" prefix:"sqlite-" envprefix:"Q_SQLITE_"`
 	Metrics   MetricsConfig   `embed:"" prefix:"metrics-" name:"metrics" envprefix:"Q_METRICS_"`
@@ -62,6 +63,11 @@ type SQSConfig struct {
 	MaxDelaySeconds  int      `name:"max-delay-seconds" default:"30" env:"MAX_DELAY_SECONDS" help:"Max allowed wait time for long polling"`
 	DelayRetryMillis int      `name:"delay-retry-millis" default:"1000" env:"DELAY_RETRY_MILLIS" help:"When long polling, how often to request new items"`
 	EndpointOverride string   `name:"endpoint-override" default:"" env:"ENDPOINT_OVERRIDE" help:"Endpoint to advertise in queue URLs. Defaults to HTTP hostname."`
+}
+
+type TLSConfig struct {
+	Cert       string `name:"cert" default:"" env:"CERT" help:"TLS Certificate"`
+	PrivateKey string `name:"private-key" default:"" env:"PRIVATE_KEY" help:"TLS Private Key"`
 }
 
 type AWSKey struct {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,0 +1,53 @@
+package metrics
+
+import (
+	"github.com/poundifdef/smoothmq/config"
+	"github.com/poundifdef/smoothmq/web"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/middleware/adaptor"
+)
+
+type Metrics struct {
+	App *web.Web
+
+	cfg config.MetricsConfig
+}
+
+func NewMetrics(cfg config.MetricsConfig, tls config.TLSConfig) *Metrics {
+	app := fiber.New(fiber.Config{
+		DisableStartupMessage: true,
+	})
+
+	m := &Metrics{
+		cfg: cfg,
+	}
+
+	m.App = &web.Web{
+		FiberApp: app,
+		Path:     "/metrics",
+		Port:     cfg.PrometheusPort,
+		TLS:      tls,
+		Type:     "Prometheus Metrics"}
+
+	m.App.FiberApp.Group(m.App.Path, adaptor.HTTPHandler(promhttp.Handler()))
+
+	return m
+}
+
+func (m *Metrics) Start() error {
+	if !m.cfg.PrometheusEnabled {
+		return nil
+	}
+
+	return m.App.Start()
+}
+
+func (m *Metrics) Stop() error {
+	if m.cfg.PrometheusEnabled {
+		return m.App.Stop()
+	}
+
+	return nil
+}

--- a/web/web.go
+++ b/web/web.go
@@ -1,0 +1,56 @@
+package web
+
+import (
+	"crypto/tls"
+	"fmt"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/poundifdef/smoothmq/config"
+)
+
+type Web struct {
+	FiberApp *fiber.App
+	Path     string
+	Port     int
+	TLS      config.TLSConfig
+	Type     string
+}
+
+func (w *Web) Start() error {
+	port := fmt.Sprintf(":%d", w.Port)
+
+	if w.TLS.Cert != "" {
+		cer, err := tls.LoadX509KeyPair(w.TLS.Cert, w.TLS.PrivateKey)
+		if err != nil {
+			panic(err)
+		}
+
+		tlsCfg := &tls.Config{Certificates: []tls.Certificate{cer}}
+
+		listener, err := tls.Listen("tcp", port, tlsCfg)
+		if err != nil {
+			panic(err)
+		}
+
+		w.OutputPort()
+		return w.FiberApp.Listener(listener)
+	}
+
+	w.OutputPort()
+	return w.FiberApp.Listen(port)
+}
+
+func (w *Web) Stop() error {
+	return w.FiberApp.Shutdown()
+}
+
+func (w *Web) OutputPort() {
+	if w.Type != "" {
+		scheme := "http"
+		if w.TLS.Cert != "" {
+			scheme = "https"
+		}
+
+		fmt.Printf("%18s: %s://localhost:%d%s\n", w.Type, scheme, w.Port, w.Path)
+	}
+}


### PR DESCRIPTION
Add config.yaml stanza to specify the TLS certificate and private key.

Move all "servers" (including single port variant) to a standard struct and have that struct setup the TLS listeners if applicable.