### PR TITLE
feat: add SQS DeleteMessageBatch operation with performance optimizations

### DIFF
--- a/models/queue.go
+++ b/models/queue.go
@@ -48,6 +48,7 @@ type Queue interface {
 	Filter(tenantId int64, queue string, filterCriteria FilterCriteria) []int64
 
 	Delete(tenantId int64, queue string, messageId int64) error
+	DeleteBatch(tenantId int64, queue string, messageIds []int64) error
 
 	Shutdown() error
 }

--- a/protocols/sqs/models.go
+++ b/protocols/sqs/models.go
@@ -145,10 +145,33 @@ type SendMessageBatchResultEntry struct {
 	SequenceNumber         string `json:"SequenceNumber,omitempty"`
 }
 
-// BatchResultErrorEntry represents a failed entry in the SendMessageBatch operation.
+// BatchResultErrorEntry represents a failed entry in batch operations.
 type BatchResultErrorEntry struct {
 	ID          string `json:"Id"`
 	SenderFault bool   `json:"SenderFault"`
 	Code        string `json:"Code"`
 	Message     string `json:"Message"`
+}
+
+// DeleteMessageBatchRequest represents the input for the DeleteMessageBatch operation.
+type DeleteMessageBatchRequest struct {
+	QueueUrl string                           `json:"QueueUrl"`
+	Entries  []DeleteMessageBatchRequestEntry `json:"Entries"`
+}
+
+// DeleteMessageBatchRequestEntry represents an entry in the DeleteMessageBatch operation.
+type DeleteMessageBatchRequestEntry struct {
+	ID            string `json:"Id"`
+	ReceiptHandle string `json:"ReceiptHandle"`
+}
+
+// DeleteMessageBatchResponse represents the output for the DeleteMessageBatch operation.
+type DeleteMessageBatchResponse struct {
+	Successful []DeleteMessageBatchResultEntry `json:"Successful"`
+	Failed     []BatchResultErrorEntry         `json:"Failed"`
+}
+
+// DeleteMessageBatchResultEntry represents a successful entry in the DeleteMessageBatch operation.
+type DeleteMessageBatchResultEntry struct {
+	ID string `json:"Id"`
 }


### PR DESCRIPTION
## Summary

- Adds the SQS `DeleteMessageBatch` API operation, allowing clients to delete up to 10 messages in a single request
- Implements batch delete at the database level for better performance instead of deleting messages one-by-one
- Optimizes Message table queries to use primary key lookups instead of slower composite index scans

## Changes

- Added `DeleteBatch` method to the `Queue` interface
- Implemented `DeleteMessageBatch` handler in the SQS protocol layer with proper error handling for individual entries
- Added `DeleteBatch` implementation in SQLite queue using batch `DELETE ... WHERE id IN (...)` queries
- Optimized existing `Dequeue` and `Delete` operations to use primary key lookups for the Message table

## Test plan

- [ ] Verify DeleteMessageBatch works with valid receipt handles
- [ ] Verify DeleteMessageBatch returns appropriate errors for invalid receipt handles
- [ ] Verify batch delete performance improvement with multiple messages
- [ ] Verify existing Delete and Dequeue operations still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)